### PR TITLE
Handle rename all default import identifiers and handle conflicts

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@trivago/prettier-plugin-sort-imports": "^5.2.2",
     "@types/eslint": "^9.6.1",
     "@types/node": "^22.13.1",
+    "@typescript-eslint/parser": "^8.29.1",
     "@typescript-eslint/typescript-estree": "^8.24.0",
     "@typescript-eslint/utils": "^8.24.0",
     "bumpp": "^10.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       '@types/node':
         specifier: ^22.13.1
         version: 22.13.5
+      '@typescript-eslint/parser':
+        specifier: ^8.29.1
+        version: 8.29.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
       '@typescript-eslint/typescript-estree':
         specifier: ^8.24.0
         version: 8.24.1(typescript@5.7.3)
@@ -896,8 +899,19 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.8.0'
 
+  '@typescript-eslint/parser@8.29.1':
+    resolution: {integrity: sha512-zczrHVEqEaTwh12gWBIJWj8nx+ayDcCJs06yoNMY0kwjMWDM6+kppljY+BxWI06d2Ja+h4+WdufDcwMnnMEWmg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.9.0'
+
   '@typescript-eslint/scope-manager@8.24.1':
     resolution: {integrity: sha512-OdQr6BNBzwRjNEXMQyaGyZzgg7wzjYKfX2ZBV3E04hUCBDv3GQCHiz9RpqdUIiVrMgJGkXm3tcEh4vFSHreS2Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/scope-manager@8.29.1':
+    resolution: {integrity: sha512-2nggXGX5F3YrsGN08pw4XpMLO1Rgtnn4AzTegC2MDesv6q3QaTU5yU7IbS1tf1IwCR0Hv/1EFygLn9ms6LIpDA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/type-utils@8.24.1':
@@ -911,11 +925,21 @@ packages:
     resolution: {integrity: sha512-9kqJ+2DkUXiuhoiYIUvIYjGcwle8pcPpdlfkemGvTObzgmYfJ5d0Qm6jwb4NBXP9W1I5tss0VIAnWFumz3mC5A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/types@8.29.1':
+    resolution: {integrity: sha512-VT7T1PuJF1hpYC3AGm2rCgJBjHL3nc+A/bhOp9sGMKfi5v0WufsX/sHCFBfNTx2F+zA6qBc/PD0/kLRLjdt8mQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/typescript-estree@8.24.1':
     resolution: {integrity: sha512-UPyy4MJ/0RE648DSKQe9g0VDSehPINiejjA6ElqnFaFIhI6ZEiZAkUI0D5MCk0bQcTf/LVqZStvQ6K4lPn/BRg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <5.8.0'
+
+  '@typescript-eslint/typescript-estree@8.29.1':
+    resolution: {integrity: sha512-l1enRoSaUkQxOQnbi0KPUtqeZkSiFlqrx9/3ns2rEDhGKfTa+88RmXqedC1zmVTOWrLc2e6DEJrTA51C9iLH5g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <5.9.0'
 
   '@typescript-eslint/utils@8.24.1':
     resolution: {integrity: sha512-OOcg3PMMQx9EXspId5iktsI3eMaXVwlhC8BvNnX6B5w9a4dVgpkQZuU8Hy67TolKcl+iFWq0XX+jbDGN4xWxjQ==}
@@ -926,6 +950,10 @@ packages:
 
   '@typescript-eslint/visitor-keys@8.24.1':
     resolution: {integrity: sha512-EwVHlp5l+2vp8CoqJm9KikPZgi3gbdZAtabKT9KPShGeOcJhsv4Zdo3oc8T8I0uKEmYoU4ItyxbptjF08enaxg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/visitor-keys@8.29.1':
+    resolution: {integrity: sha512-RGLh5CRaUEf02viP5c1Vh1cMGffQscyHe7HPAzGpfmfflFg1wUz2rYxd+OZqwpeypYvZ8UxSxuIpF++fmOzEcg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@vitest/eslint-plugin@1.1.31':
@@ -4083,8 +4111,8 @@ snapshots:
       '@eslint/js': 9.21.0
       '@eslint/markdown': 6.2.2
       '@stylistic/eslint-plugin': 2.13.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
-      '@typescript-eslint/eslint-plugin': 8.24.1(@typescript-eslint/parser@8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
-      '@typescript-eslint/parser': 8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
+      '@typescript-eslint/eslint-plugin': 8.24.1(@typescript-eslint/parser@8.29.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.29.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
       '@vitest/eslint-plugin': 1.1.31(@typescript-eslint/utils@8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)(vitest@3.0.6(@types/debug@4.1.12)(@types/node@22.13.5)(jiti@2.4.2)(tsx@4.19.3)(yaml@2.7.0))
       confusing-browser-globals: 1.0.11
       eslint: 9.21.0(jiti@2.4.2)
@@ -4097,7 +4125,7 @@ snapshots:
       eslint-plugin-clsx: 0.0.9(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
       eslint-plugin-command: 0.2.7(eslint@9.21.0(jiti@2.4.2))
       eslint-plugin-eslint-comments: 3.2.0(eslint@9.21.0(jiti@2.4.2))
-      eslint-plugin-expect-type: 0.6.2(@typescript-eslint/parser@8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
+      eslint-plugin-expect-type: 0.6.2(@typescript-eslint/parser@8.29.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
       eslint-plugin-github: 5.1.8(@types/eslint@9.6.1)(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
       eslint-plugin-import-x: 4.6.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
       eslint-plugin-jsdoc: 50.6.3(eslint@9.21.0(jiti@2.4.2))
@@ -4115,7 +4143,7 @@ snapshots:
       eslint-plugin-toml: 0.12.0(eslint@9.21.0(jiti@2.4.2))
       eslint-plugin-tsdoc: 0.4.0
       eslint-plugin-unicorn: 56.0.1(eslint@9.21.0(jiti@2.4.2))
-      eslint-plugin-unused-imports: 4.1.4(@typescript-eslint/eslint-plugin@8.24.1(@typescript-eslint/parser@8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.21.0(jiti@2.4.2))
+      eslint-plugin-unused-imports: 4.1.4(@typescript-eslint/eslint-plugin@8.24.1(@typescript-eslint/parser@8.29.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.21.0(jiti@2.4.2))
       eslint-plugin-vue: 9.32.0(eslint@9.21.0(jiti@2.4.2))
       eslint-plugin-workspaces: 0.10.1
       eslint-plugin-yml: 1.17.0(eslint@9.21.0(jiti@2.4.2))
@@ -4348,6 +4376,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/eslint-plugin@8.24.1(@typescript-eslint/parser@8.29.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.1
+      '@typescript-eslint/parser': 8.29.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
+      '@typescript-eslint/scope-manager': 8.24.1
+      '@typescript-eslint/type-utils': 8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 8.24.1
+      eslint: 9.21.0(jiti@2.4.2)
+      graphemer: 1.4.0
+      ignore: 5.3.2
+      natural-compare: 1.4.0
+      ts-api-utils: 2.0.1(typescript@5.7.3)
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/parser@8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.24.1
@@ -4360,10 +4405,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/parser@8.29.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.29.1
+      '@typescript-eslint/types': 8.29.1
+      '@typescript-eslint/typescript-estree': 8.29.1(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 8.29.1
+      debug: 4.4.0
+      eslint: 9.21.0(jiti@2.4.2)
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/scope-manager@8.24.1':
     dependencies:
       '@typescript-eslint/types': 8.24.1
       '@typescript-eslint/visitor-keys': 8.24.1
+
+  '@typescript-eslint/scope-manager@8.29.1':
+    dependencies:
+      '@typescript-eslint/types': 8.29.1
+      '@typescript-eslint/visitor-keys': 8.29.1
 
   '@typescript-eslint/type-utils@8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)':
     dependencies:
@@ -4378,10 +4440,26 @@ snapshots:
 
   '@typescript-eslint/types@8.24.1': {}
 
+  '@typescript-eslint/types@8.29.1': {}
+
   '@typescript-eslint/typescript-estree@8.24.1(typescript@5.7.3)':
     dependencies:
       '@typescript-eslint/types': 8.24.1
       '@typescript-eslint/visitor-keys': 8.24.1
+      debug: 4.4.0
+      fast-glob: 3.3.3
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.7.1
+      ts-api-utils: 2.0.1(typescript@5.7.3)
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@8.29.1(typescript@5.7.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.29.1
+      '@typescript-eslint/visitor-keys': 8.29.1
       debug: 4.4.0
       fast-glob: 3.3.3
       is-glob: 4.0.3
@@ -4406,6 +4484,11 @@ snapshots:
   '@typescript-eslint/visitor-keys@8.24.1':
     dependencies:
       '@typescript-eslint/types': 8.24.1
+      eslint-visitor-keys: 4.2.0
+
+  '@typescript-eslint/visitor-keys@8.29.1':
+    dependencies:
+      '@typescript-eslint/types': 8.29.1
       eslint-visitor-keys: 4.2.0
 
   '@vitest/eslint-plugin@1.1.31(@typescript-eslint/utils@8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)(vitest@3.0.6(@types/debug@4.1.12)(@types/node@22.13.5)(jiti@2.4.2)(tsx@4.19.3)(yaml@2.7.0))':
@@ -5172,11 +5255,11 @@ snapshots:
     dependencies:
       eslint: 9.21.0(jiti@2.4.2)
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint@9.21.0(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.29.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint@9.21.0(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.29.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
       eslint: 9.21.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
@@ -5225,9 +5308,9 @@ snapshots:
       eslint: 9.21.0(jiti@2.4.2)
       ignore: 5.3.2
 
-  eslint-plugin-expect-type@0.6.2(@typescript-eslint/parser@8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3):
+  eslint-plugin-expect-type@0.6.2(@typescript-eslint/parser@8.29.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3):
     dependencies:
-      '@typescript-eslint/parser': 8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.29.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
       '@typescript-eslint/utils': 8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
       eslint: 9.21.0(jiti@2.4.2)
       fs-extra: 11.3.0
@@ -5250,8 +5333,8 @@ snapshots:
       '@eslint/eslintrc': 3.3.0
       '@eslint/js': 9.21.0
       '@github/browserslist-config': 1.0.0
-      '@typescript-eslint/eslint-plugin': 8.24.1(@typescript-eslint/parser@8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
-      '@typescript-eslint/parser': 8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
+      '@typescript-eslint/eslint-plugin': 8.24.1(@typescript-eslint/parser@8.29.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.29.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
       aria-query: 5.3.2
       eslint: 9.21.0(jiti@2.4.2)
       eslint-config-prettier: 9.1.0(eslint@9.21.0(jiti@2.4.2))
@@ -5259,7 +5342,7 @@ snapshots:
       eslint-plugin-eslint-comments: 3.2.0(eslint@9.21.0(jiti@2.4.2))
       eslint-plugin-filenames: 1.3.2(eslint@9.21.0(jiti@2.4.2))
       eslint-plugin-i18n-text: 1.0.1(eslint@9.21.0(jiti@2.4.2))
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.21.0(jiti@2.4.2))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.29.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.21.0(jiti@2.4.2))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.21.0(jiti@2.4.2))
       eslint-plugin-no-only-tests: 3.3.0
       eslint-plugin-prettier: 5.2.3(@types/eslint@9.6.1)(eslint-config-prettier@9.1.0(eslint@9.21.0(jiti@2.4.2)))(eslint@9.21.0(jiti@2.4.2))(prettier@3.5.2)
@@ -5300,7 +5383,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.21.0(jiti@2.4.2)):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.29.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.21.0(jiti@2.4.2)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -5311,7 +5394,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.21.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint@9.21.0(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.29.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint@9.21.0(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -5323,7 +5406,7 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.29.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -5501,11 +5584,11 @@ snapshots:
       semver: 7.7.1
       strip-indent: 3.0.0
 
-  eslint-plugin-unused-imports@4.1.4(@typescript-eslint/eslint-plugin@8.24.1(@typescript-eslint/parser@8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.21.0(jiti@2.4.2)):
+  eslint-plugin-unused-imports@4.1.4(@typescript-eslint/eslint-plugin@8.24.1(@typescript-eslint/parser@8.29.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.21.0(jiti@2.4.2)):
     dependencies:
       eslint: 9.21.0(jiti@2.4.2)
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.24.1(@typescript-eslint/parser@8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
+      '@typescript-eslint/eslint-plugin': 8.24.1(@typescript-eslint/parser@8.29.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3)
 
   eslint-plugin-vue@9.32.0(eslint@9.21.0(jiti@2.4.2)):
     dependencies:

--- a/src/rules/default-import-name.test.ts
+++ b/src/rules/default-import-name.test.ts
@@ -39,8 +39,7 @@ run({
       ],
     },
     {
-      description:
-        "Should rename import to match simple file name without extension",
+      description: "Should rename import to match file name without extension",
       code: ts`import account from "./user";`,
       output: ts`import user from "./user";`,
       errors: [
@@ -134,7 +133,7 @@ run({
       ],
     },
 
-    // Usage reference tests
+    // Variable usage tests
     {
       description: "Should rename import and all its usages in the code",
       code: ts`
@@ -284,7 +283,7 @@ run({
       ],
     },
     {
-      description: "Fix multiple imports from different locations",
+      description: "Should handle multiple imports from different locations",
       code: ts`
         import a from "./user";
         import b from "./a/user";
@@ -432,34 +431,6 @@ run({
       ],
     },
     {
-      description:
-        "Should rename import and its usages if we have multiple conflicts",
-      code: tsx`
-        import B from "~/A.astro";
-        import A from "~/good/A.astro";
-        <B prop1="value">
-          <A>Child</A>
-        </B>;
-      `,
-      output: tsx`
-        import A_1 from "~/A.astro";
-        import A from "~/good/A.astro";
-        <A_1 prop1="value">
-          <A>Child</A>
-        </A_1>;
-      `,
-      errors: [
-        {
-          messageId: "unmatchedDefaultImportName",
-          data: {
-            fileName: "A.astro",
-            expectedImportName: "A_1",
-            actualImportName: "B",
-          },
-        },
-      ],
-    },
-    {
       description: "Should rename JSX component with props and children",
       code: tsx`
         import B from "~/A.astro";
@@ -479,6 +450,33 @@ run({
           data: {
             fileName: "A.astro",
             expectedImportName: "A",
+            actualImportName: "B",
+          },
+        },
+      ],
+    },
+    {
+      description: "Should handle JSX component conflicts",
+      code: tsx`
+        import B from "~/A.astro";
+        import A from "~/another/A.astro";
+        <B prop1="value">
+          <A>Child</A>
+        </B>;
+      `,
+      output: tsx`
+        import A_1 from "~/A.astro";
+        import A from "~/another/A.astro";
+        <A_1 prop1="value">
+          <A>Child</A>
+        </A_1>;
+      `,
+      errors: [
+        {
+          messageId: "unmatchedDefaultImportName",
+          data: {
+            fileName: "A.astro",
+            expectedImportName: "A_1",
             actualImportName: "B",
           },
         },

--- a/src/rules/default-import-name.test.ts
+++ b/src/rules/default-import-name.test.ts
@@ -8,6 +8,7 @@ run({
   rule,
   invalid: [
     {
+      description: "Should rename import to match .astro file name",
       code: ts`import B from "./A.astro";`,
       output: ts`import A from "./A.astro";`,
       errors: [
@@ -22,6 +23,7 @@ run({
       ],
     },
     {
+      description: "Should convert kebab-case file name to camelCase import",
       code: ts`import user from "./get-user.ts";`,
       output: ts`import getUser from "./get-user.ts";`,
       errors: [
@@ -36,6 +38,7 @@ run({
       ],
     },
     {
+      description: "Should rename import to match simple file name",
       code: ts`import account from "./user";`,
       output: ts`import user from "./user";`,
       errors: [
@@ -50,7 +53,7 @@ run({
       ],
     },
     {
-      description: "Fix multiple references",
+      description: "Should rename import and all its usages in the code",
       code: ts`
         import account from "./user";
         account.a;
@@ -75,6 +78,7 @@ run({
       ],
     },
     {
+      description: "Should handle path alias imports with @ prefix",
       code: ts`import B from "@/A.astro";`,
       output: ts`import A from "@/A.astro";`,
       errors: [
@@ -89,6 +93,7 @@ run({
       ],
     },
     {
+      description: "Should handle path alias imports with ~ prefix",
       code: ts`import B from "~/A.astro";`,
       output: ts`import A from "~/A.astro";`,
       errors: [
@@ -103,6 +108,7 @@ run({
       ],
     },
     {
+      description: "Should handle path alias imports without extension",
       code: ts`import B from "~/A";`,
       output: ts`import A from "~/A";`,
       errors: [
@@ -117,6 +123,7 @@ run({
       ],
     },
     {
+      description: "Should handle @ path alias imports without extension",
       code: ts`import B from "@/A";`,
       output: ts`import A from "@/A";`,
       errors: [
@@ -132,22 +139,48 @@ run({
     },
   ],
   valid: [
-    ts`import A from "./A.astro";`,
-    // Should convert files with - to camelCase
-    ts`import getUser from "./get-user.ts";`,
-    ts`import getUser from "./get-user";`,
-    // Should ignore 3rd party libraries
-    ts`import something from "third-party-library";`,
-    // Should ignore css files
-    ts`import styles from "./a.module.css";`,
-    // Should ignore scoped package
-    ts`import A from "@a/b";`,
-    // Should still check path alias files
-    ts`import A from "@/A.astro";`,
-    ts`import A from "~/A.astro";`,
-    ts`import A from "~/A";`,
-    ts`import A from "@/A";`,
     {
+      description: "Should accept correct import name for .astro file",
+      code: ts`import A from "./A.astro";`,
+    },
+    {
+      description: "Should accept camelCase import for kebab-case file name",
+      code: ts`import getUser from "./get-user.ts";`,
+    },
+    {
+      description: "Should accept camelCase import for kebab-case file name without extension",
+      code: ts`import getUser from "./get-user";`,
+    },
+    {
+      description: "Should ignore third-party library imports",
+      code: ts`import something from "third-party-library";`,
+    },
+    {
+      description: "Should ignore CSS module imports",
+      code: ts`import styles from "./a.module.css";`,
+    },
+    {
+      description: "Should ignore scoped package imports",
+      code: ts`import A from "@a/b";`,
+    },
+    {
+      description: "Should check path alias imports with @ prefix",
+      code: ts`import A from "@/A.astro";`,
+    },
+    {
+      description: "Should check path alias imports with ~ prefix",
+      code: ts`import A from "~/A.astro";`,
+    },
+    {
+      description: "Should check path alias imports without extension",
+      code: ts`import A from "~/A";`,
+    },
+    {
+      description: "Should check @ path alias imports without extension",
+      code: ts`import A from "@/A";`,
+    },
+    {
+      description: "Should ignore files matching ignoredSourceRegexes option",
       code: ts`import something from "./ignoredSource.astro";`,
       options: [
         {
@@ -174,7 +207,7 @@ run({
   },
   invalid: [
     {
-      description: "jsx support",
+      description: "Should rename JSX component imports and usages",
       code: tsx`
         import B from "~/A.astro";
         <B />;

--- a/src/rules/default-import-name.test.ts
+++ b/src/rules/default-import-name.test.ts
@@ -1,6 +1,7 @@
 import rule, { RULE_NAME } from "./default-import-name.js";
 import { run } from "./_test";
-import { any as ts } from "code-tag";
+import { any as ts, any as tsx } from "code-tag";
+import typescriptEslintParser from "@typescript-eslint/parser";
 
 run({
   name: RULE_NAME,
@@ -151,6 +152,47 @@ run({
       options: [
         {
           ignoredSourceRegexes: ["ignoredSource.astro$"],
+        },
+      ],
+    },
+  ],
+});
+
+run({
+  name: RULE_NAME,
+  rule,
+  languageOptions: {
+    parser: typescriptEslintParser,
+    parserOptions: {
+      projectService: true,
+      project: "./tsconfig.json",
+      tsconfigRootDir: `${import.meta.dirname}/fixtures-jsx`,
+      ecmaFeatures: {
+        jsx: true,
+      },
+    },
+  },
+  invalid: [
+    {
+      description: "jsx support",
+      code: tsx`
+        import B from "~/A.astro";
+        <B />;
+        <B a="a" />;
+      `,
+      output: tsx`
+        import A from "~/A.astro";
+        <A />;
+        <A a="a" />;
+      `,
+      errors: [
+        {
+          messageId: "unmatchedDefaultImportName",
+          data: {
+            fileName: "A.astro",
+            expectedImportName: "A",
+            actualImportName: "B",
+          },
         },
       ],
     },

--- a/src/rules/default-import-name.test.ts
+++ b/src/rules/default-import-name.test.ts
@@ -49,6 +49,31 @@ run({
       ],
     },
     {
+      description: "Fix multiple references",
+      code: ts`
+        import account from "./user";
+        account.a;
+        account.b;
+        account();
+      `,
+      output: ts`
+        import user from "./user";
+        user.a;
+        user.b;
+        user();
+      `,
+      errors: [
+        {
+          messageId: "unmatchedDefaultImportName",
+          data: {
+            fileName: "user",
+            expectedImportName: "user",
+            actualImportName: "account",
+          },
+        },
+      ],
+    },
+    {
       code: ts`import B from "@/A.astro";`,
       output: ts`import A from "@/A.astro";`,
       errors: [

--- a/src/rules/default-import-name.test.ts
+++ b/src/rules/default-import-name.test.ts
@@ -201,7 +201,7 @@ run({
           messageId: "unmatchedDefaultImportName",
           data: {
             fileName: "user",
-            expectedImportName: "user",
+            expectedImportName: "user_1",
             actualImportName: "account",
           },
         },
@@ -227,8 +227,91 @@ run({
           messageId: "unmatchedDefaultImportName",
           data: {
             fileName: "user",
-            expectedImportName: "user",
+            expectedImportName: "user_2",
             actualImportName: "account",
+          },
+        },
+      ],
+    },
+    {
+      description:
+        "Should not ignore import names that ends with _1 caused by conflict fix",
+      code: ts`
+        import user_1 from "./user";
+        const user_1 = {};
+      `,
+      output: ts`
+        import user from "./user";
+        const user = {};
+      `,
+      errors: [
+        {
+          messageId: "unmatchedDefaultImportName",
+          data: {
+            fileName: "user",
+            expectedImportName: "user",
+            actualImportName: "user_1",
+          },
+        },
+      ],
+    },
+    {
+      description:
+        "Should not ignore import names that ends with _2 caused by multiple conflict fix",
+      code: ts`
+        import user_4 from "./user";
+        const user = {};
+        const user_1 = {};
+        const user_2 = {};
+        user_4.a = 1;
+      `,
+      output: ts`
+        import user_3 from "./user";
+        const user = {};
+        const user_1 = {};
+        const user_2 = {};
+        user_3.a = 1;
+      `,
+      errors: [
+        {
+          messageId: "unmatchedDefaultImportName",
+          data: {
+            fileName: "user",
+            expectedImportName: "user_3",
+            actualImportName: "user_4",
+          },
+        },
+      ],
+    },
+    {
+      description: "Fix multiple imports from different locations",
+      code: ts`
+        import a from "./user";
+        import b from "./a/user";
+        a.ab = "ab";
+        b.acc = 1;
+      `,
+      output: ts`
+        import user from "./user";
+        import user_1 from "./a/user";
+        user.ab = "ab";
+        user_1.acc = 1;
+      `,
+      errors: [
+        {
+          messageId: "unmatchedDefaultImportName",
+          data: {
+            fileName: "user",
+            expectedImportName: "user",
+            actualImportName: "a",
+          },
+        },
+        {
+          messageId: "unmatchedDefaultImportName",
+          data: {
+            fileName: "user",
+            expectedImportName: "user",
+            actualImportName: "b",
           },
         },
       ],
@@ -239,11 +322,6 @@ run({
     {
       description: "Should accept correct import name for .astro file",
       code: ts`import A from "./A.astro";`,
-    },
-    {
-      description:
-        "Should ignore import names that ends with _ and number because this is how we fix when we have conflicts",
-      code: ts`import a_1 from "./a.ts";`,
     },
     {
       description: "Should accept correct import name for .ts file",
@@ -375,7 +453,7 @@ run({
           messageId: "unmatchedDefaultImportName",
           data: {
             fileName: "A.astro",
-            expectedImportName: "A",
+            expectedImportName: "A_1",
             actualImportName: "B",
           },
         },

--- a/src/rules/default-import-name.ts
+++ b/src/rules/default-import-name.ts
@@ -128,7 +128,8 @@ export default createEslintRule<Options, MessageIds>({
               const references = sourceCode.ast.tokens
                 .filter((token) => {
                   return (
-                    token.type === AST_TOKEN_TYPES.Identifier &&
+                    (token.type === AST_TOKEN_TYPES.Identifier ||
+                      token.type === AST_TOKEN_TYPES.JSXIdentifier) &&
                     token.value === actualImportName
                   );
                 })

--- a/src/rules/default-import-name.ts
+++ b/src/rules/default-import-name.ts
@@ -135,7 +135,7 @@ export default createEslintRule<Options, MessageIds>({
                 })
                 .map((token) => {
                   return {
-                    range: [token.range[0], token.range[1]] as const,
+                    range: token.range,
                     text: expectedImportName,
                   };
                 });


### PR DESCRIPTION
This PR allows fixing multiple references of the import by changing the variable / jsx identifier name. It also adds the suffix _ and incremental number to the name in case of naming conflict in the scope. 
