### PR TITLE
add `importPathRegexToTemplate` config

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ export default [defaultImportNameConfig()];
 🔧 Automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).
 
 | Name                                                    | Description                                 | 🔧  |
-|:--------------------------------------------------------| :------------------------------------------ | :-- |
+| :------------------------------------------------------ | :------------------------------------------ | :-- |
 | [default-import-name](src/rules/default-import-name.md) | enforce default imports matching file names | 🔧  |
 
 <!-- end auto-generated rules list -->

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,6 +12,7 @@ export default nirtamir2(
       rules: {
         "sonarjs/cognitive-complexity": "off",
         "sonarjs/no-empty-test-file": "off",
+        "no-template-curly-in-string": "off"
       },
     },
   ],

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,7 +12,10 @@ export default nirtamir2(
       rules: {
         "sonarjs/cognitive-complexity": "off",
         "sonarjs/no-empty-test-file": "off",
-        "no-template-curly-in-string": "off"
+        "no-template-curly-in-string": "off",
+
+        "sonarjs/unused-import": "off",
+        "import-x/no-duplicates": "off",
       },
     },
   ],

--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
     "eslint": "*"
   },
   "dependencies": {
-    "scule": "^1.1.1"
+    "scule": "^1.1.1",
+    "string-template-parser": "^1.2.6"
   },
   "devDependencies": {
     "@nirtamir2/eslint-config": "0.0.2-beta.20",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       scule:
         specifier: ^1.1.1
         version: 1.3.0
+      string-template-parser:
+        specifier: ^1.2.6
+        version: 1.2.6
     devDependencies:
       '@nirtamir2/eslint-config':
         specifier: 0.0.2-beta.20
@@ -3334,6 +3337,9 @@ packages:
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
     engines: {node: '>=0.6.19'}
+
+  string-template-parser@1.2.6:
+    resolution: {integrity: sha512-GsSNOkzaupvBRDKtO8j7limAd0DStJUHy+iQ0rBVaPJO9Jt+lfCVN0eJJEqqr/oBtZ5t29QhVTo9HREAdY1YxQ==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -7375,6 +7381,8 @@ snapshots:
   std-env@3.8.0: {}
 
   string-argv@0.3.2: {}
+
+  string-template-parser@1.2.6: {}
 
   string-width@4.2.3:
     dependencies:

--- a/src/rules/default-import-name.md
+++ b/src/rules/default-import-name.md
@@ -38,12 +38,12 @@ The string template format supports:
 
 - `${value}` - The original file name without extension
 - Pipes for transformations:
-  - `pascalcase` - Convert to PascalCase
-  - `camelcase` - Convert to camelCase
-  - `snakecase` - Convert to snake_case
-  - `kebabcase` - Convert to kebab-case
-  - `uppercase` - Convert to UPPERCASE
-  - `lowercase` - Convert to lowercase
+  - `pascalcase` - Convert to PascalCase (`foo-barBaz` => `FooBarBaz`)
+  - `camelcase` - Convert to camelCase (`foo-barBaz` => `fooBarBaz`)
+  - `snakecase` - Convert to snake_case (`foo-barBaz` => `foo_bar_baz`)
+  - `uppercase` - Convert to UPPERCASE (`foo-barBaz` => `FOO-BARBAZ`)
+  - `lowercase` - Convert to lowercase (`foo-barBaz` => `foo-barbaz`)
+  - `flatcase` - Convert to flatcase (without delimiters like _) (`foo-barBaz` => `foobarbaz`)
 
 ### Examples
 

--- a/src/rules/default-import-name.md
+++ b/src/rules/default-import-name.md
@@ -27,7 +27,15 @@ By default, the rule includes these mappings:
 {
   "mapImportPathToName": {
     // Default mapping for files with kebab-case
-    ".*-.*": "${value|camelcase}"
+    ".*/[a-z0-9]+(-[a-z0-9]+)+(.[a-z0-9]+)?$": "${value|camelcase}",
+    // Astro files
+    ".*.astro": "${value|pascalcase}",
+    // React files
+    ".*.tsx": "${value|pascalcase}",
+    // CSS files
+    ".*.css": "styles",
+    // SVG files
+    ".*.svg": "${value|camelcase}Src"
   }
 }
 ```
@@ -38,12 +46,11 @@ The string template format supports:
 
 - `${value}` - The original file name without extension
 - Pipes for transformations:
-  - `pascalcase` - Convert to PascalCase (`foo-barBaz` => `FooBarBaz`)
-  - `camelcase` - Convert to camelCase (`foo-barBaz` => `fooBarBaz`)
-  - `snakecase` - Convert to snake_case (`foo-barBaz` => `foo_bar_baz`)
-  - `uppercase` - Convert to UPPERCASE (`foo-barBaz` => `FOO-BARBAZ`)
-  - `lowercase` - Convert to lowercase (`foo-barBaz` => `foo-barbaz`)
-  - `flatcase` - Convert to flatcase (without delimiters like _) (`foo-barBaz` => `foobarbaz`)
+  - `pascalcase` - Convert to PascalCase
+  - `camelcase` - Convert to camelCase
+  - `snakecase` - Convert to snake_case
+  - `uppercase` - Convert to UPPERCASE
+  - `lowercase` - Convert to lowercase
 
 ### Examples
 

--- a/src/rules/default-import-name.md
+++ b/src/rules/default-import-name.md
@@ -26,15 +26,15 @@ By default, the rule includes these mappings:
 ```json
 {
   "mapImportPathToName": {
-    // Default mapping for files with kebab-case
+    // Kebab-case files to camelCase
     ".*/[a-z0-9]+(-[a-z0-9]+)+(.[a-z0-9]+)?$": "${value|camelcase}",
-    // Astro files
+    // Astro files to PascalCase
     ".*.astro": "${value|pascalcase}",
-    // React files
+    // React files to PascalCase
     ".*.tsx": "${value|pascalcase}",
-    // CSS files
+    // CSS files to 'styles'
     ".*.css": "styles",
-    // SVG files
+    // SVG files to camelCase with Src suffix
     ".*.svg": "${value|camelcase}Src"
   }
 }
@@ -123,31 +123,15 @@ import user from "./user.ts"; // ❌ Incorrect
 ```json
 {
   "mapImportPathToName": {
-    ".*\\.ts$": "use${value|pascalcase}"
+    "\\/hooks\\/.*\\.ts$": "use${value|pascalcase}"
   }
 }
 ```
 
 ```typescript
-// File: user.ts
-import useUser from "./user.ts"; // ✅ Correct
-import user from "./user.ts"; // ❌ Incorrect
-```
-
-5. **Multiple Transformations**
-
-```json
-{
-  "mapImportPathToName": {
-    "get-.*\\.ts$": "${value|snakecase|uppercase}"
-  }
-}
-```
-
-```typescript
-// File: get-user.ts
-import GET_USER from "./get-user.ts"; // ✅ Correct
-import user from "./get-user.ts"; // ❌ Incorrect
+// File: hooks/user.ts
+import useUser from "./hooks/user.ts"; // ✅ Correct
+import user from "./hooks/user.ts"; // ❌ Incorrect
 ```
 
 ### Multiple Patterns
@@ -157,14 +141,59 @@ When multiple patterns match a file, the last will be used. For example:
 ```json
 {
   "mapImportPathToName": {
-    ".*\\.ts$": "notUse{value|pascalcase}",
-    "get-.*\\.ts$": "use${value|pascalcase}"
+    ".*\\.ts$": "notUse${value|pascalcase}",
+    "\\/hooks\\/.*\\.ts$": "use${value|pascalcase}"
   }
 }
 ```
 
 ```typescript
-// File: get-user.ts
+// File: hooks/get-user.ts
 import useGetUser from "./hooks/get-user.ts"; // ✅ Correct
 import getUser from "./hooks/get-user.ts"; // ❌ Incorrect
+```
+
+## `ignoredSourceRegexes`
+
+The `ignoredSourceRegexes` option allows you to specify patterns for import sources that should be ignored by the rule.
+
+### Default Configuration
+
+By default, the rule ignores:
+
+```json
+{
+  "ignoredSourceRegexes": [
+    // Third party modules that are not path alias
+    "^(?![@~])[^.]*$",
+    // Scoped packages
+    "^@[a-zA-Z0-9-_]+/[a-zA-Z0-9-_.]+$"
+  ]
+}
+```
+
+### Examples
+
+1. **Ignore Specific Files**
+
+```json
+{
+  "ignoredSourceRegexes": ["ignoredSource.astro$"]
+}
+```
+
+```typescript
+import something from "./ignoredSource.astro"; // ✅ Ignored
+```
+
+2. **Ignore Third-party Libraries**
+
+```json
+{
+  "ignoredSourceRegexes": ["^third-party-lib"]
+}
+```
+
+```typescript
+import something from "third-party-lib"; // ✅ Ignored
 ```

--- a/src/rules/default-import-name.md
+++ b/src/rules/default-import-name.md
@@ -8,8 +8,156 @@
 
 <!-- begin auto-generated rule options list -->
 
-| Name                   | Description                              |
-| :--------------------- | :--------------------------------------- |
-| `ignoredSourceRegexes` | List of regexes to ignore import sources |
+| Name                   | Description                                                                     |
+| :--------------------- | :------------------------------------------------------------------------------ |
+| `ignoredSourceRegexes` | List of regexes to ignore import sources                                        |
+| `mapImportPathToName`  | Object mapping import path regex to import name template based on the file name |
 
 <!-- end auto-generated rule options list -->
+
+## `mapImportPathToName`
+
+The `mapImportPathToName` option allows you to define custom mappings between import paths and import names using string templates. This is useful for enforcing consistent naming conventions across your codebase.
+
+### Default Configuration
+
+By default, the rule includes these mappings:
+
+```json
+{
+  "mapImportPathToName": {
+    // Default mapping for files with kebab-case
+    ".*-.*": "${value|camelcase}"
+  }
+}
+```
+
+### String Template Format
+
+The string template format supports:
+
+- `${value}` - The original file name without extension
+- Pipes for transformations:
+  - `pascalcase` - Convert to PascalCase
+  - `camelcase` - Convert to camelCase
+  - `snakecase` - Convert to snake_case
+  - `kebabcase` - Convert to kebab-case
+  - `uppercase` - Convert to UPPERCASE
+  - `lowercase` - Convert to lowercase
+
+### Examples
+
+#### Basic File Name Matching
+
+```typescript
+import user from "./user.ts"; // ✅ Correct
+import Account from "./user.ts"; // ❌ Incorrect
+```
+
+#### Kebab-case to camelCase (Default)
+
+```typescript
+import getUser from "./get-user.ts"; // ✅ Correct
+import user from "./get-user.ts"; // ❌ Incorrect
+```
+
+#### Custom Mapping Examples
+
+1. **SVG Files with Icon Suffix**
+
+```json
+{
+  "mapImportPathToName": {
+    "\\.svg$": "${value|pascalcase}Icon"
+  }
+}
+```
+
+```typescript
+// File: logo.svg
+import LogoIcon from "./logo.svg"; // ✅ Correct
+import logo from "./logo.svg"; // ❌ Incorrect
+```
+
+2. **Constants in UPPER_SNAKE_CASE**
+
+```json
+{
+  "mapImportPathToName": {
+    "\\/constants\\/.*\\.ts$": "${value|snakecase|uppercase}"
+  }
+}
+```
+
+```typescript
+// File: constants/user-config.ts
+import USER_CONFIG from "./constants/user-config.ts"; // ✅ Correct
+import userConfig from "./constants/user-config.ts"; // ❌ Incorrect
+```
+
+3. **Service Files with Suffix**
+
+```json
+{
+  "mapImportPathToName": {
+    ".*\\.ts$": "${value|pascalcase}Service"
+  }
+}
+```
+
+```typescript
+// File: user.ts
+import UserService from "./user.ts"; // ✅ Correct
+import user from "./user.ts"; // ❌ Incorrect
+```
+
+4. **React Hooks with use Prefix**
+
+```json
+{
+  "mapImportPathToName": {
+    ".*\\.ts$": "use${value|pascalcase}"
+  }
+}
+```
+
+```typescript
+// File: user.ts
+import useUser from "./user.ts"; // ✅ Correct
+import user from "./user.ts"; // ❌ Incorrect
+```
+
+5. **Multiple Transformations**
+
+```json
+{
+  "mapImportPathToName": {
+    "get-.*\\.ts$": "${value|snakecase|uppercase}"
+  }
+}
+```
+
+```typescript
+// File: get-user.ts
+import GET_USER from "./get-user.ts"; // ✅ Correct
+import user from "./get-user.ts"; // ❌ Incorrect
+```
+
+### Multiple Patterns
+
+When multiple patterns match a file, the last will be used. For example:
+
+```json
+{
+  "mapImportPathToName": {
+    ".*\\.ts$": "notUse{value|pascalcase}",
+    "get-.*\\.ts$": "use${value|pascalcase}"
+  }
+}
+```
+
+```typescript
+// File: get-user.ts
+import useGetUser from "./hooks/get-user.ts"; // ✅ Correct
+import getUser from "./hooks/get-user.ts"; // ❌ Incorrect
+```

--- a/src/rules/default-import-name.md
+++ b/src/rules/default-import-name.md
@@ -8,16 +8,16 @@
 
 <!-- begin auto-generated rule options list -->
 
-| Name                   | Description                                                                     |
-| :--------------------- | :------------------------------------------------------------------------------ |
-| `ignoredSourceRegexes` | List of regexes to ignore import sources                                        |
-| `mapImportPathToName`  | Object mapping import path regex to import name template based on the file name |
+| Name                        | Description                                                                     |
+| :-------------------------- | :------------------------------------------------------------------------------ |
+| `ignoredSourceRegexes`      | List of regexes to ignore import sources                                        |
+| `importPathRegexToTemplate` | Object mapping import path regex to import name template based on the file name |
 
 <!-- end auto-generated rule options list -->
 
-## `mapImportPathToName`
+## `importPathRegexToTemplate`
 
-The `mapImportPathToName` option allows you to define custom mappings between import paths and import names using string templates. This is useful for enforcing consistent naming conventions across your codebase.
+The `importPathRegexToTemplate` option allows you to define custom mappings between import paths and import names using string templates. This is useful for enforcing consistent naming conventions across your codebase.
 
 ### Default Configuration
 
@@ -25,7 +25,7 @@ By default, the rule includes these mappings:
 
 ```json
 {
-  "mapImportPathToName": {
+  "importPathRegexToTemplate": {
     // Kebab-case files to camelCase
     ".*/[a-z0-9]+(-[a-z0-9]+)+(.[a-z0-9]+)?$": "${value|camelcase}",
     // Astro files to PascalCase
@@ -74,7 +74,7 @@ import user from "./get-user.ts"; // ❌ Incorrect
 
 ```json
 {
-  "mapImportPathToName": {
+  "importPathRegexToTemplate": {
     "\\.svg$": "${value|pascalcase}Icon"
   }
 }
@@ -90,7 +90,7 @@ import logo from "./logo.svg"; // ❌ Incorrect
 
 ```json
 {
-  "mapImportPathToName": {
+  "importPathRegexToTemplate": {
     "\\/constants\\/.*\\.ts$": "${value|snakecase|uppercase}"
   }
 }
@@ -106,7 +106,7 @@ import userConfig from "./constants/user-config.ts"; // ❌ Incorrect
 
 ```json
 {
-  "mapImportPathToName": {
+  "importPathRegexToTemplate": {
     ".*\\.ts$": "${value|pascalcase}Service"
   }
 }
@@ -122,7 +122,7 @@ import user from "./user.ts"; // ❌ Incorrect
 
 ```json
 {
-  "mapImportPathToName": {
+  "importPathRegexToTemplate": {
     "\\/hooks\\/.*\\.ts$": "use${value|pascalcase}"
   }
 }
@@ -140,7 +140,7 @@ When multiple patterns match a file, the last will be used. For example:
 
 ```json
 {
-  "mapImportPathToName": {
+  "importPathRegexToTemplate": {
     ".*\\.ts$": "notUse${value|pascalcase}",
     "\\/hooks\\/.*\\.ts$": "use${value|pascalcase}"
   }

--- a/src/rules/default-import-name.test.ts
+++ b/src/rules/default-import-name.test.ts
@@ -94,7 +94,7 @@ run({
       output: ts`import UserLogoIcon from "./user-logo.svg";`,
       options: [
         {
-          mapImportPathToName: {
+          importPathRegexToTemplate: {
             "\\.svg$": "${value|pascalcase}Icon",
           },
         },
@@ -117,7 +117,7 @@ run({
       output: ts`import USER_CONFIG from "./constants/user-config.ts";`,
       options: [
         {
-          mapImportPathToName: {
+          importPathRegexToTemplate: {
             "\\/constants\\/.*\\.ts$": "${value|snakecase|uppercase}",
           },
         },
@@ -140,7 +140,7 @@ run({
       output: ts`import useUser from "./hooks/user.ts";`,
       options: [
         {
-          mapImportPathToName: {
+          importPathRegexToTemplate: {
             "\\/hooks\\/.*\\.ts$": "use${value|pascalcase}",
           },
         },
@@ -162,7 +162,7 @@ run({
       output: ts`import useGetUser from "./hooks/get-user.ts";`,
       options: [
         {
-          mapImportPathToName: {
+          importPathRegexToTemplate: {
             ".*\\.ts$": "notUse${value|pascalcase}",
             "\\/hooks\\/.*\\.ts$": "use${value|pascalcase}",
           },
@@ -363,7 +363,7 @@ run({
       output: ts`import LogoIcon from "./logo.svg";`,
       options: [
         {
-          mapImportPathToName: {
+          importPathRegexToTemplate: {
             "\\.svg$": "${value|pascalcase}Icon",
           },
         },
@@ -385,7 +385,7 @@ run({
       output: ts`import UserProfileIcon from "./user-profile.svg";`,
       options: [
         {
-          mapImportPathToName: {
+          importPathRegexToTemplate: {
             "\\.svg$": "${value|pascalcase}Icon",
           },
         },
@@ -415,7 +415,7 @@ run({
       `,
       options: [
         {
-          mapImportPathToName: {
+          importPathRegexToTemplate: {
             "\\.svg$": "${value|pascalcase}Icon",
           },
         },
@@ -453,7 +453,7 @@ run({
       output: ts`import LogoIconIcon from "./logo-icon.svg";`,
       options: [
         {
-          mapImportPathToName: {
+          importPathRegexToTemplate: {
             "\\.svg$": "${value|pascalcase}Icon",
           },
         },
@@ -629,11 +629,12 @@ run({
       ],
     },
     {
-      description: "Should handle custom mapImportPathToName configuration",
+      description:
+        "Should handle custom importPathRegexToTemplate configuration",
       code: ts`import UserService from "./user.ts";`,
       options: [
         {
-          mapImportPathToName: {
+          importPathRegexToTemplate: {
             ".*\\.ts$": "${value|pascalcase}Service",
           },
         },
@@ -647,7 +648,7 @@ run({
       `,
       options: [
         {
-          mapImportPathToName: {
+          importPathRegexToTemplate: {
             ".*\\.ts$": "${value|pascalcase}Service",
           },
           ignoredSourceRegexes: ["custom-ignored.astro$"],
@@ -657,12 +658,13 @@ run({
   ],
   invalid: [
     {
-      description: "Should apply custom mapImportPathToName configuration",
+      description:
+        "Should apply custom importPathRegexToTemplate configuration",
       code: ts`import user from "./user.ts";`,
       output: ts`import UserService from "./user.ts";`,
       options: [
         {
-          mapImportPathToName: {
+          importPathRegexToTemplate: {
             ".*\\.ts$": "${value|pascalcase}Service",
           },
         },

--- a/src/rules/default-import-name.test.ts
+++ b/src/rules/default-import-name.test.ts
@@ -93,7 +93,7 @@ run({
       output: ts`import GetUser from "./get-user.ts";`,
       options: [
         {
-          mapFilenamesToImportName: {
+          mapImportPathToName: {
             "get-.*\\.ts$": "${value|pascalcase}",
           },
         },
@@ -115,7 +115,7 @@ run({
       output: ts`import GET_USER from "./get-user.ts";`,
       options: [
         {
-          mapFilenamesToImportName: {
+          mapImportPathToName: {
             "get-.*\\.ts$": "${value|snakecase|uppercase}",
           },
         },
@@ -137,7 +137,7 @@ run({
       output: ts`import MY_CONFIG from "./constants/my-config.ts";`,
       options: [
         {
-          mapFilenamesToImportName: {
+          mapImportPathToName: {
             "\\/constants\\/.*\\.ts$": "${value|snakecase|uppercase}",
           },
         },
@@ -159,7 +159,7 @@ run({
       output: ts`import UserService from "./user.ts";`,
       options: [
         {
-          mapFilenamesToImportName: {
+          mapImportPathToName: {
             ".*\\.ts$": "${value|pascalcase}Service",
           },
         },
@@ -181,7 +181,7 @@ run({
       output: ts`import useUser from "./user.ts";`,
       options: [
         {
-          mapFilenamesToImportName: {
+          mapImportPathToName: {
             ".*\\.ts$": "use${value|pascalcase}",
           },
         },
@@ -203,7 +203,7 @@ run({
       output: ts`import useGetUser from "./get-user.ts";`,
       options: [
         {
-          mapFilenamesToImportName: {
+          mapImportPathToName: {
             ".*\\.ts$": "use${value|pascalcase}",
             "get-.*\\.ts$": "use${value|pascalcase}",
           },
@@ -458,7 +458,7 @@ run({
       output: ts`import LogoIcon from "./logo.svg";`,
       options: [
         {
-          mapFilenamesToImportName: {
+          mapImportPathToName: {
             "\\.svg$": "${value|pascalcase}Icon",
           },
         },
@@ -480,7 +480,7 @@ run({
       output: ts`import UserProfileIcon from "./user-profile.svg";`,
       options: [
         {
-          mapFilenamesToImportName: {
+          mapImportPathToName: {
             "\\.svg$": "${value|pascalcase}Icon",
           },
         },
@@ -510,7 +510,7 @@ run({
       `,
       options: [
         {
-          mapFilenamesToImportName: {
+          mapImportPathToName: {
             "\\.svg$": "${value|pascalcase}Icon",
           },
         },
@@ -548,7 +548,7 @@ run({
       output: ts`import LogoIconIcon from "./logo-icon.svg";`,
       options: [
         {
-          mapFilenamesToImportName: {
+          mapImportPathToName: {
             "\\.svg$": "${value|pascalcase}Icon",
           },
         },

--- a/src/rules/default-import-name.test.ts
+++ b/src/rules/default-import-name.test.ts
@@ -54,7 +54,7 @@ run({
       ],
     },
 
-    // Kebab-case to camelCase conversion tests
+    // Default kebab-case to camelCase conversion tests
     {
       description: "Should convert kebab-case file name to camelCase import",
       code: ts`import user from "./get-user.ts";`,
@@ -80,6 +80,141 @@ run({
           data: {
             fileName: "get-user-profile.ts",
             expectedImportName: "getUserProfile",
+            actualImportName: "user",
+          },
+        },
+      ],
+    },
+
+    // Custom mapping tests
+    {
+      description: "Should apply custom mapping for specific file pattern",
+      code: ts`import user from "./get-user.ts";`,
+      output: ts`import GetUser from "./get-user.ts";`,
+      options: [
+        {
+          mapFilenamesToImportName: {
+            "get-.*\\.ts$": "${value|pascalcase}",
+          },
+        },
+      ],
+      errors: [
+        {
+          messageId: "unmatchedDefaultImportName",
+          data: {
+            fileName: "get-user.ts",
+            expectedImportName: "GetUser",
+            actualImportName: "user",
+          },
+        },
+      ],
+    },
+    {
+      description: "Should apply custom mapping with multiple transformations",
+      code: ts`import user from "./get-user.ts";`,
+      output: ts`import GET_USER from "./get-user.ts";`,
+      options: [
+        {
+          mapFilenamesToImportName: {
+            "get-.*\\.ts$": "${value|snakecase|uppercase}",
+          },
+        },
+      ],
+      errors: [
+        {
+          messageId: "unmatchedDefaultImportName",
+          data: {
+            fileName: "get-user.ts",
+            expectedImportName: "GET_USER",
+            actualImportName: "user",
+          },
+        },
+      ],
+    },
+    {
+      description: "Should apply custom mapping for directory-specific files",
+      code: ts`import myConfig from "./constants/my-config.ts";`,
+      output: ts`import MY_CONFIG from "./constants/my-config.ts";`,
+      options: [
+        {
+          mapFilenamesToImportName: {
+            "\\/constants\\/.*\\.ts$": "${value|snakecase|uppercase}",
+          },
+        },
+      ],
+      errors: [
+        {
+          messageId: "unmatchedDefaultImportName",
+          data: {
+            fileName: "my-config.ts",
+            expectedImportName: "MY_CONFIG",
+            actualImportName: "myConfig",
+          },
+        },
+      ],
+    },
+    {
+      description: "Should apply custom mapping with suffix",
+      code: ts`import user from "./user.ts";`,
+      output: ts`import UserService from "./user.ts";`,
+      options: [
+        {
+          mapFilenamesToImportName: {
+            ".*\\.ts$": "${value|pascalcase}Service",
+          },
+        },
+      ],
+      errors: [
+        {
+          messageId: "unmatchedDefaultImportName",
+          data: {
+            fileName: "user.ts",
+            expectedImportName: "UserService",
+            actualImportName: "user",
+          },
+        },
+      ],
+    },
+    {
+      description: "Should apply custom mapping with prefix",
+      code: ts`import user from "./user.ts";`,
+      output: ts`import useUser from "./user.ts";`,
+      options: [
+        {
+          mapFilenamesToImportName: {
+            ".*\\.ts$": "use${value|pascalcase}",
+          },
+        },
+      ],
+      errors: [
+        {
+          messageId: "unmatchedDefaultImportName",
+          data: {
+            fileName: "user.ts",
+            expectedImportName: "useUser",
+            actualImportName: "user",
+          },
+        },
+      ],
+    },
+    {
+      description: "Should apply multiple custom mappings in order",
+      code: ts`import user from "./get-user.ts";`,
+      output: ts`import useGetUser from "./get-user.ts";`,
+      options: [
+        {
+          mapFilenamesToImportName: {
+            ".*\\.ts$": "use${value|pascalcase}",
+            "get-.*\\.ts$": "use${value|pascalcase}",
+          },
+        },
+      ],
+      errors: [
+        {
+          messageId: "unmatchedDefaultImportName",
+          data: {
+            fileName: "get-user.ts",
+            expectedImportName: "useGetUser",
             actualImportName: "user",
           },
         },
@@ -425,77 +560,6 @@ run({
             fileName: "logo-icon.svg",
             expectedImportName: "LogoIconIcon",
             actualImportName: "logo",
-          },
-        },
-      ],
-    },
-
-    // String template parser format tests
-    {
-      description:
-        "Should transform import name using string template parser with pascalcase",
-      code: ts`import user from "./get-user.ts";`,
-      output: ts`import GetUser from "./get-user.ts";`,
-      options: [
-        {
-          mapFilenamesToImportName: {
-            "get-.*\\.ts$": "${value|pascalcase}",
-          },
-        },
-      ],
-      errors: [
-        {
-          messageId: "unmatchedDefaultImportName",
-          data: {
-            fileName: "get-user.ts",
-            expectedImportName: "GetUser",
-            actualImportName: "user",
-          },
-        },
-      ],
-    },
-    {
-      description:
-        "Should transform import name using string template parser with uppercase",
-      code: ts`import user from "./get-user.ts";`,
-      output: ts`import GET_USER from "./get-user.ts";`,
-      options: [
-        {
-          mapFilenamesToImportName: {
-            "get-.*\\.ts$": "${value|snakecase|uppercase}",
-          },
-        },
-      ],
-      errors: [
-        {
-          messageId: "unmatchedDefaultImportName",
-          data: {
-            fileName: "get-user.ts",
-            expectedImportName: "GET_USER",
-            actualImportName: "user",
-          },
-        },
-      ],
-    },
-    {
-      description:
-        "Should transform import name using string template parser with multiple pipes",
-      code: ts`import myConfig from "./constants/my-config.ts";`,
-      output: ts`import MY_CONFIG from "./constants/my-config.ts";`,
-      options: [
-        {
-          mapFilenamesToImportName: {
-            "\\/constants\\/.*\\.ts$": "${value|snakecase|uppercase}",
-          },
-        },
-      ],
-      errors: [
-        {
-          messageId: "unmatchedDefaultImportName",
-          data: {
-            fileName: "my-config.ts",
-            expectedImportName: "MY_CONFIG",
-            actualImportName: "myConfig",
           },
         },
       ],

--- a/src/rules/default-import-name.test.ts
+++ b/src/rules/default-import-name.test.ts
@@ -110,6 +110,28 @@ run({
       ],
     },
     {
+      description: "Should convert SVG files to camelCase with Src suffix",
+      code: ts`import logo from "./user-logo.svg";`,
+      output: ts`import userLogoSrc from "./user-logo.svg";`,
+      options: [
+        {
+          mapImportPathToName: {
+            "\\.svg$": "${value|camelcase}Src",
+          },
+        },
+      ],
+      errors: [
+        {
+          messageId: "unmatchedDefaultImportName",
+          data: {
+            fileName: "user-logo.svg",
+            expectedImportName: "userLogoSrc",
+            actualImportName: "logo",
+          },
+        },
+      ],
+    },
+    {
       description: "Should apply custom mapping with multiple transformations",
       code: ts`import user from "./get-user.ts";`,
       output: ts`import GET_USER from "./get-user.ts";`,

--- a/src/rules/default-import-name.test.ts
+++ b/src/rules/default-import-name.test.ts
@@ -1,8 +1,7 @@
 import rule, { RULE_NAME } from "./default-import-name.js";
 import { run } from "./_test";
-import { any as astro, any as ts, any as tsx } from "code-tag";
+import { any as ts, any as tsx } from "code-tag";
 import typescriptEslintParser from "@typescript-eslint/parser";
-import astroEslintParser from "astro-eslint-parser";
 
 run({
   name: RULE_NAME,
@@ -316,6 +315,275 @@ run({
         },
       ],
     },
+
+    // SVG Icon pattern mapping tests
+    {
+      description: "Should add Icon suffix to SVG imports",
+      code: ts`import logo from "./logo.svg";`,
+      output: ts`import LogoIcon from "./logo.svg";`,
+      options: [
+        {
+          mapFilenamesToImportName: {
+            "\\.svg$": "${value|pascalcase}Icon",
+          },
+        },
+      ],
+      errors: [
+        {
+          messageId: "unmatchedDefaultImportName",
+          data: {
+            fileName: "logo.svg",
+            expectedImportName: "LogoIcon",
+            actualImportName: "logo",
+          },
+        },
+      ],
+    },
+    {
+      description: "Should handle kebab-case SVG filenames with Icon suffix",
+      code: ts`import user from "./user-profile.svg";`,
+      output: ts`import UserProfileIcon from "./user-profile.svg";`,
+      options: [
+        {
+          mapFilenamesToImportName: {
+            "\\.svg$": "${value|pascalcase}Icon",
+          },
+        },
+      ],
+      errors: [
+        {
+          messageId: "unmatchedDefaultImportName",
+          data: {
+            fileName: "user-profile.svg",
+            expectedImportName: "UserProfileIcon",
+            actualImportName: "user",
+          },
+        },
+      ],
+    },
+    {
+      description: "Should handle multiple SVG imports with Icon suffix",
+      code: ts`
+        import logo from "./logo.svg";
+        import user from "./user-profile.svg";
+        import settings from "./settings.svg";
+      `,
+      output: ts`
+        import LogoIcon from "./logo.svg";
+        import UserProfileIcon from "./user-profile.svg";
+        import SettingsIcon from "./settings.svg";
+      `,
+      options: [
+        {
+          mapFilenamesToImportName: {
+            "\\.svg$": "${value|pascalcase}Icon",
+          },
+        },
+      ],
+      errors: [
+        {
+          messageId: "unmatchedDefaultImportName",
+          data: {
+            fileName: "logo.svg",
+            expectedImportName: "LogoIcon",
+            actualImportName: "logo",
+          },
+        },
+        {
+          messageId: "unmatchedDefaultImportName",
+          data: {
+            fileName: "user-profile.svg",
+            expectedImportName: "UserProfileIcon",
+            actualImportName: "user",
+          },
+        },
+        {
+          messageId: "unmatchedDefaultImportName",
+          data: {
+            fileName: "settings.svg",
+            expectedImportName: "SettingsIcon",
+            actualImportName: "settings",
+          },
+        },
+      ],
+    },
+    {
+      description: "Should handle SVG imports with existing Icon suffix",
+      code: ts`import logo from "./logo-icon.svg";`,
+      output: ts`import LogoIconIcon from "./logo-icon.svg";`,
+      options: [
+        {
+          mapFilenamesToImportName: {
+            "\\.svg$": "${value|pascalcase}Icon",
+          },
+        },
+      ],
+      errors: [
+        {
+          messageId: "unmatchedDefaultImportName",
+          data: {
+            fileName: "logo-icon.svg",
+            expectedImportName: "LogoIconIcon",
+            actualImportName: "logo",
+          },
+        },
+      ],
+    },
+    {
+      description: "Should not affect non-SVG imports",
+      code: ts`import user from "./user.ts";`,
+      output: ts`import user from "./user.ts";`,
+      options: [
+        {
+          mapFilenamesToImportName: {
+            "\\.svg$": "${value|pascalcase}Icon",
+          },
+        },
+      ],
+      errors: [
+        {
+          messageId: "unmatchedDefaultImportName",
+          data: {
+            fileName: "user.ts",
+            expectedImportName: "user",
+            actualImportName: "user",
+          },
+        },
+      ],
+    },
+
+    // String template parser format tests
+    {
+      description: "Should transform import name using string template parser with pascalcase",
+      code: ts`import user from "./get-user.ts";`,
+      output: ts`import GetUser from "./get-user.ts";`,
+      options: [
+        {
+          mapFilenamesToImportName: {
+            "get-.*\\.ts$": "${value|pascalcase}",
+          },
+        },
+      ],
+      errors: [
+        {
+          messageId: "unmatchedDefaultImportName",
+          data: {
+            fileName: "get-user.ts",
+            expectedImportName: "GetUser",
+            actualImportName: "user",
+          },
+        },
+      ],
+    },
+    {
+      description: "Should transform import name using string template parser with uppercase",
+      code: ts`import user from "./get-user.ts";`,
+      output: ts`import GETUSER from "./get-user.ts";`,
+      options: [
+        {
+          mapFilenamesToImportName: {
+            "get-.*\\.ts$": "${value|uppercase}",
+          },
+        },
+      ],
+      errors: [
+        {
+          messageId: "unmatchedDefaultImportName",
+          data: {
+            fileName: "get-user.ts",
+            expectedImportName: "GETUSER",
+            actualImportName: "user",
+          },
+        },
+      ],
+    },
+    {
+      description: "Should transform import name using string template parser with multiple pipes",
+      code: ts`import user from "./get-user.ts";`,
+      output: ts`import GET_USER from "./get-user.ts";`,
+      options: [
+        {
+          mapFilenamesToImportName: {
+            "get-.*\\.ts$": "${value|uppercase|lowercase}",
+          },
+        },
+      ],
+      errors: [
+        {
+          messageId: "unmatchedDefaultImportName",
+          data: {
+            fileName: "get-user.ts",
+            expectedImportName: "GET_USER",
+            actualImportName: "user",
+          },
+        },
+      ],
+    },
+
+    // Default template tests
+    {
+      description: "Should use default template for files without specific mapping",
+      code: ts`import user from "./get-user.ts";`,
+      output: ts`import getUser from "./get-user.ts";`,
+      options: [
+        {
+          defaultTemplate: "${value|camelcase}",
+        },
+      ],
+      errors: [
+        {
+          messageId: "unmatchedDefaultImportName",
+          data: {
+            fileName: "get-user.ts",
+            expectedImportName: "getUser",
+            actualImportName: "user",
+          },
+        },
+      ],
+    },
+    {
+      description: "Should use custom default template for files without specific mapping",
+      code: ts`import user from "./get-user.ts";`,
+      output: ts`import GetUser from "./get-user.ts";`,
+      options: [
+        {
+          defaultTemplate: "${value|pascalcase}",
+        },
+      ],
+      errors: [
+        {
+          messageId: "unmatchedDefaultImportName",
+          data: {
+            fileName: "get-user.ts",
+            expectedImportName: "GetUser",
+            actualImportName: "user",
+          },
+        },
+      ],
+    },
+    {
+      description: "Should use default template when no mapping matches",
+      code: ts`import user from "./get-user.ts";`,
+      output: ts`import getUser from "./get-user.ts";`,
+      options: [
+        {
+          defaultTemplate: "${value|camelcase}",
+          mapFilenamesToImportName: {
+            "\\.svg$": "${value|pascalcase}Icon",
+          },
+        },
+      ],
+      errors: [
+        {
+          messageId: "unmatchedDefaultImportName",
+          data: {
+            fileName: "get-user.ts",
+            expectedImportName: "getUser",
+            actualImportName: "user",
+          },
+        },
+      ],
+    },
   ],
   valid: [
     // Basic valid cases
@@ -479,45 +747,6 @@ run({
             fileName: "A.astro",
             expectedImportName: "A_1",
             actualImportName: "B",
-          },
-        },
-      ],
-    },
-  ],
-});
-
-run({
-  name: RULE_NAME,
-  rule,
-  languageOptions: {
-    parser: astroEslintParser,
-  },
-  invalid: [
-    {
-      description: "Astro",
-      code: astro`---
-import Blog from "../../layouts/ArticleLayout.astro";
----
-
-<Blog>
-  test
-</Blog>
-`,
-      output: astro`---
-import ArticleLayout from "../../layouts/ArticleLayout.astro";
----
-
-<ArticleLayout>
-  test
-</ArticleLayout>
-`,
-      errors: [
-        {
-          messageId: "unmatchedDefaultImportName",
-          data: {
-            fileName: "ArticleLayout.astro",
-            expectedImportName: "ArticleLayout",
-            actualImportName: "Blog",
           },
         },
       ],

--- a/src/rules/default-import-name.test.ts
+++ b/src/rules/default-import-name.test.ts
@@ -429,32 +429,11 @@ run({
         },
       ],
     },
-    {
-      description: "Should not affect non-SVG imports",
-      code: ts`import user from "./user.ts";`,
-      output: ts`import user from "./user.ts";`,
-      options: [
-        {
-          mapFilenamesToImportName: {
-            "\\.svg$": "${value|pascalcase}Icon",
-          },
-        },
-      ],
-      errors: [
-        {
-          messageId: "unmatchedDefaultImportName",
-          data: {
-            fileName: "user.ts",
-            expectedImportName: "user",
-            actualImportName: "user",
-          },
-        },
-      ],
-    },
 
     // String template parser format tests
     {
-      description: "Should transform import name using string template parser with pascalcase",
+      description:
+        "Should transform import name using string template parser with pascalcase",
       code: ts`import user from "./get-user.ts";`,
       output: ts`import GetUser from "./get-user.ts";`,
       options: [
@@ -476,35 +455,14 @@ run({
       ],
     },
     {
-      description: "Should transform import name using string template parser with uppercase",
-      code: ts`import user from "./get-user.ts";`,
-      output: ts`import GETUSER from "./get-user.ts";`,
-      options: [
-        {
-          mapFilenamesToImportName: {
-            "get-.*\\.ts$": "${value|uppercase}",
-          },
-        },
-      ],
-      errors: [
-        {
-          messageId: "unmatchedDefaultImportName",
-          data: {
-            fileName: "get-user.ts",
-            expectedImportName: "GETUSER",
-            actualImportName: "user",
-          },
-        },
-      ],
-    },
-    {
-      description: "Should transform import name using string template parser with multiple pipes",
+      description:
+        "Should transform import name using string template parser with uppercase",
       code: ts`import user from "./get-user.ts";`,
       output: ts`import GET_USER from "./get-user.ts";`,
       options: [
         {
           mapFilenamesToImportName: {
-            "get-.*\\.ts$": "${value|uppercase|lowercase}",
+            "get-.*\\.ts$": "${value|snakecase|uppercase}",
           },
         },
       ],
@@ -519,57 +477,15 @@ run({
         },
       ],
     },
-
-    // Default template tests
     {
-      description: "Should use default template for files without specific mapping",
-      code: ts`import user from "./get-user.ts";`,
-      output: ts`import getUser from "./get-user.ts";`,
+      description:
+        "Should transform import name using string template parser with multiple pipes",
+      code: ts`import myConfig from "./constants/my-config.ts";`,
+      output: ts`import MY_CONFIG from "./constants/my-config.ts";`,
       options: [
         {
-          defaultTemplate: "${value|camelcase}",
-        },
-      ],
-      errors: [
-        {
-          messageId: "unmatchedDefaultImportName",
-          data: {
-            fileName: "get-user.ts",
-            expectedImportName: "getUser",
-            actualImportName: "user",
-          },
-        },
-      ],
-    },
-    {
-      description: "Should use custom default template for files without specific mapping",
-      code: ts`import user from "./get-user.ts";`,
-      output: ts`import GetUser from "./get-user.ts";`,
-      options: [
-        {
-          defaultTemplate: "${value|pascalcase}",
-        },
-      ],
-      errors: [
-        {
-          messageId: "unmatchedDefaultImportName",
-          data: {
-            fileName: "get-user.ts",
-            expectedImportName: "GetUser",
-            actualImportName: "user",
-          },
-        },
-      ],
-    },
-    {
-      description: "Should use default template when no mapping matches",
-      code: ts`import user from "./get-user.ts";`,
-      output: ts`import getUser from "./get-user.ts";`,
-      options: [
-        {
-          defaultTemplate: "${value|camelcase}",
           mapFilenamesToImportName: {
-            "\\.svg$": "${value|pascalcase}Icon",
+            "\\/constants\\/.*\\.ts$": "${value|snakecase|uppercase}",
           },
         },
       ],
@@ -577,9 +493,9 @@ run({
         {
           messageId: "unmatchedDefaultImportName",
           data: {
-            fileName: "get-user.ts",
-            expectedImportName: "getUser",
-            actualImportName: "user",
+            fileName: "my-config.ts",
+            expectedImportName: "MY_CONFIG",
+            actualImportName: "myConfig",
           },
         },
       ],

--- a/src/rules/default-import-name.ts
+++ b/src/rules/default-import-name.ts
@@ -4,13 +4,15 @@ import { AST_NODE_TYPES, AST_TOKEN_TYPES } from "@typescript-eslint/utils";
 import type { RuleContext } from "@typescript-eslint/utils/ts-eslint";
 import { evaluateStringTemplate } from "string-template-parser";
 
+type ImportPathToNameConfig = Record<string, string>;
+
 export const RULE_NAME = "default-import-name";
 export type MessageIds = "unmatchedDefaultImportName";
 export type Options =
   | [
       {
         ignoredSourceRegexes?: Array<string>;
-        mapImportPathToName?: Record<string, string>;
+        mapImportPathToName?: ImportPathToNameConfig;
       },
     ]
   | [];
@@ -21,22 +23,124 @@ function shouldIgnoreFile({
 }: {
   sourceImport: string;
   ignoredSourceRegexes: Set<string>;
-}) {
+}): boolean {
   return [...ignoredSourceRegexes.values()].some((regex) => {
-    return new RegExp(regex).test(sourceImport);
+    try {
+      return new RegExp(regex).test(sourceImport);
+    } catch (error) {
+      console.warn(`Invalid regex pattern: ${regex}`, error);
+      return false;
+    }
   });
 }
 
-export const defaultImportPathToNameConfig = {
+export const defaultImportPathToNameConfig: ImportPathToNameConfig = {
   // Default mapping for files with kebab-case
-  ".*-.*": "${value|camelcase}",
+  ".*/[a-z0-9]+(-[a-z0-9]+)+(.[a-z0-9]+)?$": "${value|camelcase}",
+  // Astro files
+  ".*.astro": "${value|pascalcase}",
+  // React files
+  ".*.tsx": "${value|pascalcase}",
+  // CSS files
+  ".*.css": "styles",
+  // SVG files
+  ".*.svg": "${value|camelcase}Src",
 };
+
+export const defaultIgnoredSourceRegexes = [
+  /**
+   * Third party modules that are not path alias
+   * File that does not include "."
+   * and not start with "~" or "\@" which are common path alias
+   */
+  "^(?![@~])[^.]*$",
+  // ignore scoped packages
+  "^@[a-zA-Z0-9-_]+\/[a-zA-Z0-9-_.]+$",
+];
+
+const pipeFunctions = {
+  pascalcase: (val: string) => pascalCase(val),
+  camelcase: (val: string) => camelCase(val),
+  snakecase: (val: string) => snakeCase(val),
+  flatcase: (val: string) => flatCase(val),
+  uppercase: (val: string) => val.toUpperCase(),
+  lowercase: (val: string) => val.toLowerCase(),
+} as const;
+
+function transformSnippetText(snippetText: string, value: string): string {
+  try {
+    return evaluateStringTemplate(snippetText, { value }, pipeFunctions);
+  } catch (error) {
+    console.warn(`Failed to transform snippet: ${snippetText}`, error);
+    return value;
+  }
+}
+
+function getFileNameWithoutExtension(fileName: string): string {
+  return fileName.includes(".")
+    ? fileName.split(".").slice(0, -1).join(".")
+    : fileName;
+}
+
+function getExpectedImportNameWithoutConflicts({
+  context,
+  actualImportName,
+  sourceImport,
+  fileName,
+  mappingConfig,
+}: {
+  context: RuleContext<MessageIds, Options>;
+  actualImportName: string;
+  sourceImport: string;
+  fileName: string;
+  mappingConfig: ImportPathToNameConfig;
+}): string {
+  const fileNameWithoutExtension = getFileNameWithoutExtension(fileName);
+  let expectedImportName = fileNameWithoutExtension;
+
+  // Apply mappingConfig if provided
+  for (const [regex, snippet] of Object.entries(mappingConfig).toReversed()) {
+    try {
+      if (new RegExp(regex).test(sourceImport)) {
+        const transformedName = transformSnippetText(
+          snippet,
+          fileNameWithoutExtension,
+        );
+        expectedImportName = transformedName;
+        break;
+      }
+    } catch (error) {
+      console.warn(`Failed to apply regex pattern: ${regex}`, error);
+    }
+  }
+
+  // Handle naming conflicts
+  const existingVariables = new Set(
+    context.sourceCode.ast.tokens
+      .filter(
+        (token) =>
+          (token.type === AST_TOKEN_TYPES.Identifier ||
+            token.type === AST_TOKEN_TYPES.JSXIdentifier) &&
+          token.value !== actualImportName,
+      )
+      .map((token) => token.value),
+  );
+
+  let newImportName = expectedImportName;
+  let suffix = 1;
+  while (existingVariables.has(newImportName)) {
+    newImportName = `${expectedImportName}_${suffix}`;
+    suffix++;
+  }
+  return newImportName;
+}
 
 export default createEslintRule<Options, MessageIds>({
   name: RULE_NAME,
   defaultOptions: [
     {
       mapImportPathToName: defaultImportPathToNameConfig,
+      ignoredSourceRegexes: defaultIgnoredSourceRegexes,
     },
   ],
   meta: {
@@ -52,23 +156,18 @@ export default createEslintRule<Options, MessageIds>({
         properties: {
           ignoredSourceRegexes: {
             description: "List of regexes to ignore import sources",
-            anyOf: [
-              {
-                type: ["array"],
-                items: {
-                  type: ["string"],
-                },
-              },
-            ],
+            type: "array",
+            items: {
+              type: "string",
+            },
           },
           mapImportPathToName: {
             description:
               "Object mapping import path regex to import name template based on the file name",
-            anyOf: [
-              {
-                type: ["object"],
-              },
-            ],
+            type: "object",
+            additionalProperties: {
+              type: "string",
+            },
           },
         },
       },
@@ -81,25 +180,13 @@ export default createEslintRule<Options, MessageIds>({
 
   create(context) {
     const mappingConfig = (context.options[0]?.mapImportPathToName ??
-      defaultImportPathToNameConfig) as Record<string, string>;
+      defaultImportPathToNameConfig) as ImportPathToNameConfig;
 
     const configExcludedRegexes =
       (context.options[0]?.ignoredSourceRegexes as Array<string> | undefined) ??
-      [];
+      defaultIgnoredSourceRegexes;
 
-    const ignoredSourceRegexes = new Set([
-      // ignored file extensions
-      ".css$",
-      /**
-       * Third party modules that are not path alias
-       * File that does not include "."
-       * and not start with "~" or "\@" which are common path alias
-       */
-      "^(?![@~])[^.]*$",
-      // ignore scoped packages
-      "^@[a-zA-Z0-9-_]+\/[a-zA-Z0-9-_.]+$",
-      ...configExcludedRegexes,
-    ]);
+    const ignoredSourceRegexes = new Set(configExcludedRegexes);
 
     return {
       ImportDeclaration(node) {
@@ -177,74 +264,3 @@ export default createEslintRule<Options, MessageIds>({
     };
   },
 });
-
-function transformSnippetText(snippetText: string, value: string): string {
-  const pipeFunctions = {
-    pascalcase: (val: string) => pascalCase(val),
-    camelcase: (val: string) => camelCase(val),
-    snakecase: (val: string) => snakeCase(val),
-    flatcase: (val: string) => flatCase(val),
-    uppercase: (val: string) => val.toUpperCase(),
-    lowercase: (val: string) => val.toLowerCase(),
-  };
-
-  return evaluateStringTemplate(snippetText, { value }, pipeFunctions);
-}
-
-function getExpectedImportNameWithoutConflicts({
-  context,
-  actualImportName,
-  sourceImport,
-  fileName,
-  mappingConfig,
-}: {
-  context: RuleContext<MessageIds, Options>;
-  actualImportName: string;
-  sourceImport: string;
-  fileName: string;
-  mappingConfig: Record<string, string> | null;
-}) {
-  const fileNameWithoutExtension = fileName.includes(".")
-    ? fileName.split(".").slice(0, -1).join(".")
-    : fileName;
-
-  let expectedImportName = fileNameWithoutExtension;
-
-  if (mappingConfig != null) {
-    for (const [regex, snippet] of Object.entries(mappingConfig).toReversed()) {
-      if (new RegExp(regex).test(sourceImport)) {
-        try {
-          // Transform the snippet text with the file name
-          const transformedName = transformSnippetText(
-            snippet,
-            fileNameWithoutExtension,
-          );
-          expectedImportName = transformedName;
-          break; // Use the first matching pattern
-        } catch (error) {
-          // If snippet parsing fails, continue with the original name
-          console.warn(`Failed to parse snippet for ${fileName}:`, error);
-        }
-      }
-    }
-  }
-
-  const existingVariables = new Set(
-    context.sourceCode.ast.tokens
-      .filter(
-        (token) =>
-          (token.type === AST_TOKEN_TYPES.Identifier ||
-            token.type === AST_TOKEN_TYPES.JSXIdentifier) &&
-          token.value !== actualImportName,
-      )
-      .map((token) => token.value),
-  );
-
-  let newImportName = expectedImportName;
-  let suffix = 1;
-  while (existingVariables.has(newImportName)) {
-    newImportName = `${expectedImportName}_${suffix}`;
-    suffix++;
-  }
-  return newImportName;
-}

--- a/src/rules/default-import-name.ts
+++ b/src/rules/default-import-name.ts
@@ -10,7 +10,7 @@ export type Options =
   | [
       {
         ignoredSourceRegexes?: Array<string>;
-        mapFilenamesToImportName?: Record<string, string>;
+        mapImportPathToName?: Record<string, string>;
       },
     ]
   | [];
@@ -27,9 +27,7 @@ function shouldIgnoreFile({
   });
 }
 
-export const defaultFilenamesToImportNameConfig = {
-  // Default mapping for all files
-  ".*": "${value}",
+export const defaultImportPathToNameConfig = {
   // Default mapping for files with kebab-case
   ".*-.*": "${value|camelcase}",
 };
@@ -38,7 +36,7 @@ export default createEslintRule<Options, MessageIds>({
   name: RULE_NAME,
   defaultOptions: [
     {
-      mapFilenamesToImportName: defaultFilenamesToImportNameConfig,
+      mapImportPathToName: defaultImportPathToNameConfig,
     },
   ],
   meta: {
@@ -63,9 +61,9 @@ export default createEslintRule<Options, MessageIds>({
               },
             ],
           },
-          mapFilenamesToImportName: {
+          mapImportPathToName: {
             description:
-              "Object mapping fileName regex to import name based on the file name",
+              "Object mapping import path regex to import name template based on the file name",
             anyOf: [
               {
                 type: ["object"],
@@ -82,8 +80,8 @@ export default createEslintRule<Options, MessageIds>({
   },
 
   create(context) {
-    const mappingConfig = (context.options[0]?.mapFilenamesToImportName ??
-      defaultFilenamesToImportNameConfig) as Record<string, string>;
+    const mappingConfig = (context.options[0]?.mapImportPathToName ??
+      defaultImportPathToNameConfig) as Record<string, string>;
 
     const configExcludedRegexes =
       (context.options[0]?.ignoredSourceRegexes as Array<string> | undefined) ??
@@ -213,7 +211,6 @@ function getExpectedImportNameWithoutConflicts({
 
   let expectedImportName = fileNameWithoutExtension;
 
-  // Apply mappingConfig if provided
   if (mappingConfig != null) {
     for (const [regex, snippet] of Object.entries(mappingConfig).toReversed()) {
       if (new RegExp(regex).test(sourceImport)) {

--- a/src/rules/default-import-name.ts
+++ b/src/rules/default-import-name.ts
@@ -1,4 +1,4 @@
-import { camelCase, flatCase, kebabCase, pascalCase, snakeCase } from "scule";
+import { camelCase, flatCase, pascalCase, snakeCase } from "scule";
 import { createEslintRule } from "../utils";
 import { AST_NODE_TYPES, AST_TOKEN_TYPES } from "@typescript-eslint/utils";
 import type { RuleContext } from "@typescript-eslint/utils/ts-eslint";
@@ -182,7 +182,6 @@ function transformSnippetText(snippetText: string, value: string): string {
   const pipeFunctions = {
     pascalcase: (val: string) => pascalCase(val),
     camelcase: (val: string) => camelCase(val),
-    kebabcase: (val: string) => kebabCase(val),
     snakecase: (val: string) => snakeCase(val),
     flatcase: (val: string) => flatCase(val),
     uppercase: (val: string) => val.toUpperCase(),


### PR DESCRIPTION
Closes #2 
This PR adds `importPathRegexToTemplate` config to enable advanced template configuration per regex.

The `importPathRegexToTemplate` option allows you to define custom mappings between import paths and import names using string templates. This is useful for enforcing consistent naming conventions across your codebase.